### PR TITLE
add variable number of results to admin/sidebar

### DIFF
--- a/assets/javascripts/discourse/widgets/sidebar-category-posts.js.es6
+++ b/assets/javascripts/discourse/widgets/sidebar-category-posts.js.es6
@@ -1,7 +1,7 @@
 import { createWidget } from 'discourse/widgets/widget';
 import { getLatestPosts } from 'discourse/plugins/discourse-sidebar-blocks/discourse/helpers/latest-posts-category';
 import { categoryBadgeHTML } from 'discourse/helpers/category-link';
-import RawHtml from 'discourse/widgets/raw-html'; 
+import RawHtml from 'discourse/widgets/raw-html';
 import { h } from 'virtual-dom';
 
 export default createWidget('sidebar-category-posts', {
@@ -29,9 +29,9 @@ export default createWidget('sidebar-category-posts', {
       }
 
       if (result.length) {
+        var max = parseInt(this.siteSettings.sidebar_num_results) - 1;
         for (var i = result.length - 1; i >= 0; i--) {
-          // limit to 6 max
-          if (i > 5) {
+          if (i > max) {
             result.splice(i, 1);
           }
         }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,3 +3,4 @@ en:
     sidebar_enable: "Show sidebar on the right list screens."
     sidebar_block_order: "Include blocks for the sidebar. Enter category slugs, 'latest_replies' for the latest replies block and/or 'custom_html' for the custom HTML from the field below."
     sidebar_custom_content: "Custom HTML content. To show this, you must include 'custom_html' in block list above."
+    sidebar_num_results: "Number of results to display"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,3 +10,6 @@ plugins:
     type: text
     default: ''
     client: true
+  sidebar_num_results:
+    default: '6'
+    client: true


### PR DESCRIPTION
Hi @pmusaraj,

I added a small feature to allow a variable amount of results for each sidebar block. 3 is in my image examples, but I tried 6+ and it worked just fine.

I made this change because in my use case, I'd like to display more than 6.

<img width="1130" alt="screen shot 2017-01-13 at 12 35 41 am" src="https://cloud.githubusercontent.com/assets/5934106/21921846/442454ea-d928-11e6-8a5e-1981fcdfde36.png">
<img width="744" alt="screen shot 2017-01-13 at 12 35 33 am" src="https://cloud.githubusercontent.com/assets/5934106/21921847/443fa678-d928-11e6-855e-88e824284673.png">

-Jeffrey
